### PR TITLE
Fix switch labels

### DIFF
--- a/src/components/MonsterPicker.tsx
+++ b/src/components/MonsterPicker.tsx
@@ -86,6 +86,7 @@ export default function MonsterPicker({
                     <Form.Switch
                         checked={expansions[index]}
                         onChange={() => handleToggleExpansions(index)}
+                        id={t(`exps.${name}`)}
                         label={t(`exps.${name}`)}
                         key={name}
                     />

--- a/src/components/TerrainTokenPicker.tsx
+++ b/src/components/TerrainTokenPicker.tsx
@@ -64,6 +64,7 @@ export default function TerrainTokenPicker({
                 <Form.Switch
                     checked={skellige}
                     onChange={() => handleSkellige()}
+                    id={t("exps.skellige")}
                     label={t("exps.skellige")}
                 />
             </Row>


### PR DESCRIPTION
Clicking labels near switches (in Monster Roller and Location Picker) should interact with those switches.